### PR TITLE
Fix page layout breaking by delaying nav button until exit animation is done

### DIFF
--- a/src/components/layout/Navbar/NavButton.tsx
+++ b/src/components/layout/Navbar/NavButton.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { Container, Typography, MenuItem } from "@mui/material";
 
 // Context
@@ -7,37 +7,54 @@ import { useCallback } from "react";
 
 export interface NavButtonProps {
     to: string;
+    /**
+     * If true this will prevent the button from being clicked
+     */
+    animating?: boolean;
     isMobile?: boolean;
     children?: string | JSX.Element;
+    onClick?: () => void;
 }
 
 function NavButton(props: NavButtonProps) {
+    const { to, animating, isMobile, children, onClick } = props;
+
     const location = useLocation();
     const { update } = useRouteContext();
+    const navigate = useNavigate();
 
     // Actions
-    const onButtonClicked = useCallback(() => {
-        update(props.to);
-    }, []);
+    const handleLinkClick: React.MouseEventHandler<HTMLAnchorElement> =
+        useCallback(
+            (evt) => {
+                evt.preventDefault();
+                if (!animating) {
+                    onClick?.();
+                    update(to);
+                    navigate(to);
+                }
+            },
+            [onClick, animating, navigate]
+        );
 
     // This is the render for the component
     const ComponentRender = (
         <Typography
-            variant={location.pathname === props.to ? "nav-active" : "nav"}
+            variant={location.pathname === to ? "nav-active" : "nav"}
             sx={{
                 userSelect: "none",
             }}
         >
-            {props.children}
+            {children}
         </Typography>
     );
 
     // This is the component itself
-    const Component = props.isMobile ? (
+    const Component = isMobile ? (
         <MenuItem
             sx={{
-                padding: props.isMobile ? "1.2rem 32px" : "0",
-                borderBottom: props.isMobile
+                padding: isMobile ? "1.2rem 32px" : "0",
+                borderBottom: isMobile
                     ? "1px solid rgba(255, 255, 255, 0.08)"
                     : "none",
             }}
@@ -54,8 +71,8 @@ function NavButton(props: NavButtonProps) {
                 color: "inherit",
                 textDecoration: "none",
             }}
-            to={props.to}
-            onMouseDown={onButtonClicked}
+            to={to}
+            onClick={handleLinkClick}
         >
             {Component}
         </Link>

--- a/src/components/layout/Navbar/NavMobile.tsx
+++ b/src/components/layout/Navbar/NavMobile.tsx
@@ -13,6 +13,8 @@ export interface NavMobileProps {
     drawer: boolean;
     setDrawer: (open: boolean) => void;
     toggleDrawer: () => void;
+    animating?: boolean;
+    onClick?: () => void;
 }
 
 function NavMobile(props: NavMobileProps) {
@@ -33,7 +35,13 @@ function NavMobile(props: NavMobileProps) {
                     // noNav is used to hide routes from the navbar
                     .filter((route) => !route.noNav)
                     .map((route, index) => (
-                        <NavButton key={index} to={route.path} isMobile>
+                        <NavButton
+                            key={index}
+                            to={route.path}
+                            animating={props.animating}
+                            onClick={props.onClick}
+                            isMobile
+                        >
                             {route.name}
                         </NavButton>
                     ))}

--- a/src/components/layout/Navbar/index.tsx
+++ b/src/components/layout/Navbar/index.tsx
@@ -86,6 +86,8 @@ function Navbar() {
                             drawer={drawerOpen}
                             setDrawer={setDrawerOpen}
                             toggleDrawer={toggleDrawer}
+                            animating={animating}
+                            onClick={handleClick}
                         />
                     ) : (
                         // Container doesn't support variant, use ID to enable nav styles

--- a/src/components/layout/Routing/index.tsx
+++ b/src/components/layout/Routing/index.tsx
@@ -8,7 +8,11 @@ import { useRouteContext } from "../../../context/RouteContext";
 // Resources
 import routes from "../../../data/routes";
 
-const X_DURATION = 0.4;
+/**
+ * The duration the x axis takes to complete one phase of the animation.
+ * This will be used to prevent you from navigation while the animation is still exiting
+ */
+export const X_DURATION = 0.4;
 const OPACITY_DURATION = 0.3;
 const DESKTOP_SPRING = {
     stiffness: 90,
@@ -46,9 +50,9 @@ function Routing(props: RoutingProps) {
     return (
         <AnimatePresence initial={false} mode="wait">
             <Routes location={location} key={location.pathname}>
-                {routes.map((route, index) => (
+                {routes.map((route) => (
                     <Route
-                        key={index}
+                        key={route.path}
                         path={route.path}
                         element={
                             <motion.div

--- a/src/context/RouteContext.ts
+++ b/src/context/RouteContext.ts
@@ -7,9 +7,12 @@ export interface RouteContextType {
     update: (newRoute: Route["path"]) => void;
 }
 
-export const useRouteContext = create<RouteContextType>((set) => ({
+export const useRouteContext = create<RouteContextType>((set, get) => ({
     current: window.location.pathname,
     previous: null,
-    update: (newRoute: Route["path"]) =>
-        set((state) => ({ current: newRoute, previous: state.current })),
+    update: (newRoute: Route["path"]) => {
+        // If the new route is the same as the current route, do nothing
+        if (get().current === newRoute) return;
+        set((state) => ({ current: newRoute, previous: state.current }));
+    },
 }));


### PR DESCRIPTION
This PR handles the fix for page layout breaking.

## Issue
If you clicked another nav button and navigated to that route before the previous route had fully completed it's exit transition it would lock the new route as the primary route forever.
What does this mean? It's hard to explain but essentially if you went to any other route it would show your current and not swap to the new route. So if I clicked projects before the about page exited, if I tried going to about or home it would only show projects and if I tried going back to projects it would only show nothing. Broken...

## Fix
Essentially the best thing I could come up with was delaying the nav button click until the exit animation is completed. This is done via exporting the global variable called `X_DURATION` this makes sure this fix doesn't break if the duration ever changes.